### PR TITLE
use real references in application logic instead of id's

### DIFF
--- a/kanban_app/app/components/Editable.jsx
+++ b/kanban_app/app/components/Editable.jsx
@@ -1,7 +1,5 @@
 import React from 'react';
-import {reactiveComponent} from 'mobservable';
 
-@reactiveComponent
 export default class Editable extends React.Component {
   constructor(props) {
     super(props);

--- a/kanban_app/app/components/Lane.jsx
+++ b/kanban_app/app/components/Lane.jsx
@@ -10,57 +10,58 @@ import LaneStore from '../stores/LaneStore';
 const noteTarget = {
   hover(targetProps, monitor) {
     const sourceProps = monitor.getItem();
-    const sourceData = sourceProps.data || {};
+    const sourceData = sourceProps.data;
+    const lane = targetProps.lane;
 
-    if(!targetProps.notes.length) {
+    if(!lane.notes.length) {
       LaneStore.attachToLane({
-        laneId: targetProps.id,
-        noteId: sourceData.id
+        lane: lane,
+        note: sourceData
       });
     }
   }
 };
 
-@reactiveComponent
 @DropTarget(ItemTypes.NOTE, noteTarget, connect => ({
   connectDropTarget: connect.dropTarget()
 }))
+@reactiveComponent
 export default class Lane extends React.Component {
   render() {
-    const { connectDropTarget, id, name, notes, ...props } = this.props;
-
+    const { connectDropTarget, lane, ...props } = this.props;
+    const { name, notes } = lane;
     return connectDropTarget(
       <div {...props}>
         <div className='lane-header'>
           <Editable className='lane-name' value={name}
-            onEdit={this.editName.bind(null, id)} />
+            onEdit={this.editName.bind(null, lane)} />
           <div className='lane-add-note'>
-            <button onClick={this.addNote.bind(null, id)}>+</button>
+            <button onClick={this.addNote.bind(null, lane)}>+</button>
           </div>
         </div>
-        <Notes items={NoteStore.get(notes)}
+        <Notes items={notes}
           onEdit={this.editNote}
-          onDelete={this.deleteNote.bind(null, id)} />
+          onDelete={this.deleteNote.bind(null, lane)} />
       </div>
     );
   }
-  addNote(laneId) {
-    const noteId = NoteStore.addNote({task: 'New task'});
-    LaneStore.attachToLane({laneId, noteId});
+  addNote(lane) {
+    const note = NoteStore.addNote({task: 'New task'});
+    LaneStore.attachToLane({lane, note});
   }
-  editNote(noteId, task) {
-    NoteStore.editNote(noteId, task);
+  editNote(note, task) {
+    NoteStore.editNote(note, task);
   }
-  deleteNote(laneId, noteId) {
-    NoteStore.deleteNote(noteId);
-    LaneStore.detachFromLane({laneId, noteId});
+  deleteNote(lane, note) {
+    NoteStore.deleteNote(note);
+    LaneStore.detachFromLane({lane, note});
   }
-  editName(id, name) {
+  editName(lane, name) {
     if(name) {
-      LaneStore.editLane(id, name);
+      LaneStore.editLane(lane, name);
     }
     else {
-      LaneStore.deleteLane(id);
+      LaneStore.deleteLane(lane);
     }
   }
 }

--- a/kanban_app/app/components/Lanes.jsx
+++ b/kanban_app/app/components/Lanes.jsx
@@ -10,6 +10,6 @@ export default class Lanes extends React.Component {
     return <div className='lanes'>{lanes.map(this.renderLane)}</div>;
   }
   renderLane(lane) {
-    return <Lane className='lane' key={`lane${lane.id}`} {...lane} />;
+    return <Lane className='lane' key={`lane${lane.id}`} lane={lane} />;
   }
 }

--- a/kanban_app/app/components/Note.jsx
+++ b/kanban_app/app/components/Note.jsx
@@ -13,9 +13,9 @@ const noteSource = {
 
 const noteTarget = {
   hover(targetProps, monitor) {
-    const targetData = targetProps.data || {};
+    const targetData = targetProps.data;
     const sourceProps = monitor.getItem();
-    const sourceData = sourceProps.data || {};
+    const sourceData = sourceProps.data;
 
     if(sourceData.id !== targetData.id) {
       targetProps.onMove({sourceData, targetData});
@@ -23,13 +23,13 @@ const noteTarget = {
   }
 };
 
-@reactiveComponent
 @DragSource(ItemTypes.NOTE, noteSource, (connect) => ({
   connectDragSource: connect.dragSource()
 }))
 @DropTarget(ItemTypes.NOTE, noteTarget, connect => ({
   connectDropTarget: connect.dropTarget()
 }))
+@reactiveComponent
 export default class Note extends React.Component {
   render() {
     const {connectDragSource, connectDropTarget,

--- a/kanban_app/app/components/Notes.jsx
+++ b/kanban_app/app/components/Notes.jsx
@@ -22,8 +22,8 @@ export default class Notes extends React.Component {
         data={note} key={`note${note.id}`}>
         <Editable
           value={note.task}
-          onEdit={this.props.onEdit.bind(null, note.id)}
-          onDelete={this.props.onDelete.bind(null, note.id)} />
+          onEdit={this.props.onEdit.bind(null, note)}
+          onDelete={this.props.onDelete.bind(null, note)} />
       </Note>
     );
   }

--- a/kanban_app/app/stores/LaneStore.js
+++ b/kanban_app/app/stores/LaneStore.js
@@ -82,12 +82,6 @@ class LaneStore {
   move({sourceData, targetData}) {
     const lanes = this.lanes;
 
-    if(!lanes) {
-      debugger;
-      // XXXXX: why this can happen?
-      return;
-    }
-
     const sourceLane = lanes.filter((lane) => {
       return lane.notes.indexOf(sourceData) >= 0;
     })[0];
@@ -97,18 +91,11 @@ class LaneStore {
     const sourceNoteIndex = sourceLane.notes.indexOf(sourceData);
     const targetNoteIndex = targetLane.notes.indexOf(targetData);
 
-    if(sourceLane === targetLane) {
-      // move at once to avoid complications
-      sourceLane.notes.splice(sourceNoteIndex, 1);
-      sourceLane.notes.splice(targetNoteIndex, 0, sourceData);
-    }
-    else {
-      // get rid of the source
-      sourceLane.notes.splice(sourceNoteIndex, 1);
+    // get rid of the source
+    sourceLane.notes.splice(sourceNoteIndex, 1);
 
-      // and move it to target
-      targetLane.notes.splice(targetNoteIndex, 0, sourceData);
-    }
+    // and move it to target
+    targetLane.notes.splice(targetNoteIndex, 0, sourceData);
   }
 }
 

--- a/kanban_app/app/stores/NoteStore.js
+++ b/kanban_app/app/stores/NoteStore.js
@@ -20,50 +20,27 @@ class NoteStore {
   }
   addNote({task}) {
     const id = uuid.v4();
+    const note = {id, task};
+    this.notes.push(note);
 
-    this.notes.push({id, task});
-
-    return id;
+    return note;
   }
-  editNote(id, task) {
+  editNote(note, task) {
+    if(!note < 0) {
+      return;
+    }
+
+    note.task = task
+  }
+  deleteNote(note) {
     const notes = this.notes;
-    const noteIndex = this.findNote(id);
+    const noteIndex = notes.indexOf(note);
 
     if(noteIndex < 0) {
       return;
     }
 
-    this.notes[noteIndex].task = task
-  }
-  deleteNote(id) {
-    const notes = this.notes;
-    const noteIndex = this.findNote(id);
-
-    if(noteIndex < 0) {
-      return;
-    }
-
-    this.notes.splice(noteIndex, 1);
-  }
-  findNote(id) {
-    const notes = this.notes;
-    const noteIndex = notes.findIndex((note) => note.id === id);
-
-    if(noteIndex < 0) {
-      console.warn('Failed to find note', notes, id);
-    }
-
-    return noteIndex;
-  }
-  get(ids) {
-    const notes = this.notes;
-    const notesIds = notes.map((note) => note.id);
-
-    if(ids) {
-      return ids.map((id) => notes[notesIds.indexOf(id)]);
-    }
-
-    return [];
+    notes.splice(noteIndex, 1);
   }
 }
 


### PR DESCRIPTION
as discussed; most store logic becomes simpler when just passing around objects instead of id's. With mutable data structures you can safely do this, because after each mutation all references lingering around are still valid and fresh.

I tried to keep all the code as much as possible in the current code style. But some of the pre conditions in the store functions could probably removed to futher simplify stuff.

Did some minor renaming in variable names that were postfixed with  `Id` but actually contained an index position, to avoid confusion.
